### PR TITLE
fix ValueError when clipping g with min-max also when g.size == 9

### DIFF
--- a/xopto/mcbase/mcpf/hga.py
+++ b/xopto/mcbase/mcpf/hga.py
@@ -128,7 +128,7 @@ class Hga(PfBase):
                 self._g[1, 1] = g[1] 
                 self._g[2, 2] = g[2] 
             else:
-                self._g[:] = min(max(g, -1.0), 1.0)
+                self._g[:] = np.clip(g, -1.0, 1.0)
 
     g = property(_get_g, _set_g, None, 'Anisotropy tensor.')
 


### PR DESCRIPTION
I noticed that the `ValueError` issue with the multielement g array encountered in the hga pf was fixed only in line [126](https://github.com/xopto/pyxopto/blob/be45fd6d44696b5a40a327dd0f494d46f5585fda/xopto/mcbase/mcpf/hga.py#L126C16-L126C42) but not in line [131](https://github.com/xopto/pyxopto/blob/be45fd6d44696b5a40a327dd0f494d46f5585fda/xopto/mcbase/mcpf/hga.py#L131), which also needs it.