### PR TITLE
replace deprecated scipy.integrate.simps with scipy.integrate.simpson

### DIFF
--- a/xopto/diffusion/srr.py
+++ b/xopto/diffusion/srr.py
@@ -21,7 +21,7 @@
 ################################# End license ##################################
 
 import numpy as np
-from scipy.integrate import simps
+from scipy.integrate import simpson
 
 def fresnel_s_polarized(theta:float, n1: float, n2: float) -> float:
     '''
@@ -127,8 +127,8 @@ def _fresnel_j(theta: float, nmedium: float, noutside: float) -> float:
 def r_eff(nmedium: float, noutside: float, steps: int = 10000) -> float:
     theta = np.linspace(0, np.pi/2.0, steps)
 
-    r_phi = simps(_fresnel_phi(theta, nmedium, noutside), dx=theta[1] - theta[0])
-    r_j = simps(_fresnel_j(theta, nmedium, noutside), dx=theta[1] - theta[0])
+    r_phi = simpson(_fresnel_phi(theta, nmedium, noutside), dx=theta[1] - theta[0])
+    r_j = simpson(_fresnel_j(theta, nmedium, noutside), dx=theta[1] - theta[0])
 
     return (r_phi + r_j)/(2.0 - r_phi + r_j)
 
@@ -159,13 +159,13 @@ class SRDA:
             1.0 - fresnel_unpolarized(theta, nmedium, noutside))*\
             np.cos(theta)*np.sin(theta)
 
-        self._back_hemi_coeff1 = simps(back_hemi_coeff1, dx=theta[1]-theta[0])
+        self._back_hemi_coeff1 = simpson(back_hemi_coeff1, dx=theta[1]-theta[0])
 
         back_hemi_coeff2 = 1.5*(
             1.0 - fresnel_unpolarized(theta, nmedium, noutside))*\
             np.cos(theta)**2*np.sin(theta)
 
-        self._back_hemi_coeff2 = simps(back_hemi_coeff2, dx=theta[1] - theta[0])
+        self._back_hemi_coeff2 = simpson(back_hemi_coeff2, dx=theta[1] - theta[0])
 
         self._R_eff = r_eff(nmedium, noutside, steps)
 

--- a/xopto/mcbase/mcrmax.py
+++ b/xopto/mcbase/mcrmax.py
@@ -21,7 +21,7 @@
 ################################# End license ##################################
 
 import numpy as np
-from scipy.integrate import simps
+from scipy.integrate import simpson
 
 from xopto.diffusion.srr import SRDA
 
@@ -120,12 +120,12 @@ class RmaxDiffusion:
 
     def _r_total(self) -> float:
         r = np.linspace(0, self.R_MAX, self.STEPS)
-        return simps(
+        return simpson(
             2.0*np.pi*self._da(r, self._mua, self._musr)*r, dx=r[1] - r[0])
 
     def _residual(self, i) -> float:
         r = np.linspace(self._rmin + (i - 1)*self._dr, self.R_MAX, self.STEPS)
-        return simps(
+        return simpson(
             2.0*np.pi*self._da(r, self._mua, self._musr)*r, dx=r[1] - r[0])
 
     def _find_rmax(self) -> float:

--- a/xopto/mcbase/mcutil/axis.py
+++ b/xopto/mcbase/mcutil/axis.py
@@ -232,9 +232,9 @@ class RadialAxis(Axis):
         The spacing of points in the RadialAxis is uneven even if logscale is
         set to False, since correction of the bin centers depends on the
         absolute position of the bin.
-        If using data from RadialAxis with the simpson integration method make
+        If using data from RadialAxis with the Simpson integration method make
         sure to use a version that does not require a fixed step (specify x
-        instead of dx in a call to scipy.integrate.simps).
+        instead of dx in a call to scipy.integrate.simpson).
         If using the :py:meth:`xopto.util.hankel.discrete_simpson` method make
         sure to set the value of the uneven parameter to True.
         '''

--- a/xopto/mcbase/mcutil/fourier.py
+++ b/xopto/mcbase/mcutil/fourier.py
@@ -23,8 +23,7 @@
 import numpy as np
 
 # Import the Symmetric Fourier Transform class
-from scipy.interpolate import interp1d
-from scipy.integrate import quad, simps
+from scipy.integrate import simpson
 
 def _uneven(array):
     tmp = np.diff(array)
@@ -85,8 +84,8 @@ def discreteSimpson(frequency: list or tuple or np.ndarray,
     for index in range(np_freqs.size):
         f = fpts*np.exp(-2.0*np.pi*1j*xpts*np_freqs[index])
         if out.ndim > 1:
-            out[:, index] = simps(f, x, dx=dx)
+            out[:, index] = simpson(f, x, dx=dx)
         else:
-            out[index] = simps(f, x, dx=dx)
+            out[index] = simpson(f, x, dx=dx)
 
     return out

--- a/xopto/mcml/test/validate.py
+++ b/xopto/mcml/test/validate.py
@@ -26,8 +26,6 @@ import pickle
 import time
 
 import numpy as np
-from scipy import io
-from scipy.integrate import simps
 
 from xopto.mcbase.mctest import McTest
 

--- a/xopto/mcvox/test/validate.py
+++ b/xopto/mcvox/test/validate.py
@@ -26,8 +26,6 @@ import pickle
 import time
 
 import numpy as np
-from scipy import io
-from scipy.integrate import simps
 
 from xopto.mcbase.mctest import McTest
 

--- a/xopto/pf/miefractal.py
+++ b/xopto/pf/miefractal.py
@@ -22,8 +22,6 @@
 
 from typing import Tuple
 
-import numpy as np
-
 from .pfbase import PfBase
 from .miepd import MiePd
 from .distribution import Fractal

--- a/xopto/pf/mieml.py
+++ b/xopto/pf/mieml.py
@@ -23,7 +23,6 @@
 from typing import List, Tuple
 
 import numpy as np
-from scipy.integrate import simps, quad
 from scattnlay import scattnlay
 
 from .pfbase import PfBase

--- a/xopto/pf/miemlfractal.py
+++ b/xopto/pf/miemlfractal.py
@@ -20,13 +20,10 @@
 # along with PyXOpto. If not, see <https://www.gnu.org/licenses/>.
 ################################# End license ##################################
 
-from typing import Callable, Tuple
-
-import numpy as np
-from scipy.integrate import simps, quad
+from typing import Tuple
 
 from .distribution import Fractal
-from .miemlpd import MieMlPd, ComplexVector, FloatVector
+from .miemlpd import MieMlPd, ComplexVector
 
 
 class MieMlFractal(MieMlPd):

--- a/xopto/pf/miemlnormal.py
+++ b/xopto/pf/miemlnormal.py
@@ -20,8 +20,6 @@
 # along with PyXOpto. If not, see <https://www.gnu.org/licenses/>.
 ################################# End license ##################################
 
-import numpy as np
-
 from .distribution import Normal
 from .miemlpd import MieMlPd, ComplexVector, FloatVector
 

--- a/xopto/pf/miemlpd.py
+++ b/xopto/pf/miemlpd.py
@@ -23,7 +23,7 @@
 from typing import Callable, Tuple
 
 import numpy as np
-from scipy.integrate import simps, quad
+from scipy.integrate import simpson, quad
 
 from .pfbase import PfBase
 from .mieml import MieMl, ComplexVector, FloatVector
@@ -196,9 +196,9 @@ class MieMlPd(PfBase):
                 Scs_p[i] = mieml.scs()*self._pdpts[i]
                 Ecs_p[i] = mieml.ecs()*self._pdpts[i]
 
-            self._scs = simps(Scs_p, dx=self._dd)
-            self._ecs = simps(Ecs_p, dx=self._dd)
-            self._g1 = simps(G1_mieml*Scs_p, dx=self._dd)/self._scs
+            self._scs = simpson(Scs_p, dx=self._dd)
+            self._ecs = simpson(Ecs_p, dx=self._dd)
+            self._g1 = simpson(G1_mieml*Scs_p, dx=self._dd)/self._scs
 
     @staticmethod
     def _g1_scs(nlayers, nmedium: ComplexVector, diameters: FloatVector,
@@ -283,7 +283,7 @@ class MieMlPd(PfBase):
 
     def _mieml_pd(self, Pf):
         self._pdpts.shape = (self._D.size, 1)
-        pf = simps(Pf*self._pdpts, dx=self._dd, axis=0)
+        pf = simpson(Pf*self._pdpts, dx=self._dd, axis=0)
         return pf
 
     def _mieml_quad_pd(self, costheta):

--- a/xopto/pf/mienormal.py
+++ b/xopto/pf/mienormal.py
@@ -22,8 +22,6 @@
 
 from typing import Callable
 
-import numpy as np
-
 from .pfbase import PfBase
 from .miepd import MiePd
 from .distribution import Normal

--- a/xopto/pf/miepd.py
+++ b/xopto/pf/miepd.py
@@ -23,7 +23,7 @@
 from typing import Callable, Tuple
 
 import numpy as np
-from scipy.integrate import quad, simps
+from scipy.integrate import quad, simpson
 
 from .pfbase import PfBase
 from .mie import Mie
@@ -131,9 +131,9 @@ class MiePd(PfBase):
                 Scs_p[i] = mie.scs()*self._pdpts[i]
                 Ecs_p[i] = mie.ecs()*self._pdpts[i]
 
-            self._scs = simps(Scs_p, dx=self._dd)
-            self._ecs = simps(Ecs_p, dx=self._dd)
-            self._g1 = simps(G1_mie*Scs_p, dx=self._dd)/self._scs
+            self._scs = simpson(Scs_p, dx=self._dd)
+            self._ecs = simpson(Ecs_p, dx=self._dd)
+            self._g1 = simpson(G1_mie*Scs_p, dx=self._dd)/self._scs
 
     @staticmethod
     def _g1_scs(nsphere: float or complex, nmedium: float or complex,
@@ -215,7 +215,7 @@ class MiePd(PfBase):
 
     def _mie_pd(self, Pf: np.ndarray) -> np.ndarray:
         self._pdpts.shape = (self._D.size, 1)
-        pf = simps(Pf*self._pdpts, dx=self._dd, axis=0)
+        pf = simpson(Pf*self._pdpts, dx=self._dd, axis=0)
         return pf
 
     def _mie_pd_quad(self, costheta: np.ndarray) -> np.ndarray:

--- a/xopto/pf/miepolystyrene.py
+++ b/xopto/pf/miepolystyrene.py
@@ -22,8 +22,6 @@
 
 from typing import Tuple
 
-import numpy as np
-
 from .mie import Mie
 from .miefractal import MieFractal
 from .mienormal import MieNormal

--- a/xopto/pf/pfbase.py
+++ b/xopto/pf/pfbase.py
@@ -23,7 +23,7 @@
 from typing import Tuple
 
 import numpy as np
-from scipy.integrate import quad, simps
+from scipy.integrate import quad, simpson
 from scipy.optimize import minimize
 from scipy.interpolate import interp1d
 
@@ -56,7 +56,7 @@ def fastg(n: int, pf: np.ndarray, costheta: np.ndarray = None) -> float:
     if costheta is None:
         costheta = np.linspace(-1.0, 1.0, pf.size)
 
-    return simps(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
+    return simpson(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
                  dx=costheta[1] - costheta[0])
 
 def fastgs(last: int, pf: np.ndarray, costheta: np.ndarray = None,
@@ -94,8 +94,8 @@ def fastgs(last: int, pf: np.ndarray, costheta: np.ndarray = None,
         out = np.zeros([last + 1])
 
     for n in range(last + 1):
-        out[n] = simps(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
-                       dx=costheta[1] - costheta[0])
+        out[n] = simpson(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
+                         dx=costheta[1] - costheta[0])
     return out
 
 
@@ -318,8 +318,8 @@ class PfBase:
         if pf is None:
             pf = self(costheta)
 
-        return simps(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
-                     dx=costheta[1] - costheta[0])
+        return simpson(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
+                       dx=costheta[1] - costheta[0])
 
     def fastgs(self, last: int, npts: int = 1000, pf: np.ndarray = None,
                costheta: np.ndarray =None) -> np.ndarray:
@@ -363,8 +363,8 @@ class PfBase:
 
         G = np.zeros([last + 1])
         for n in range(last + 1):
-            G[n] = simps(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
-                         dx=costheta[1] - costheta[0])
+            G[n] = simpson(pf*np.polynomial.legendre.Legendre.basis(n)(costheta),
+                           dx=costheta[1] - costheta[0])
         return G
 
     def cdf(self, costheta: np.ndarray, meth: str = 'simpson',

--- a/xopto/util/color/cie.py
+++ b/xopto/util/color/cie.py
@@ -24,7 +24,7 @@ import os.path
 from typing import Tuple
 
 import numpy as np
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.interpolate import interp1d
 
 from xopto import DATA_PATH
@@ -431,9 +431,9 @@ class Observer:
         cmf = self.xyz_cmf(wavelengths)
 
         return \
-            simps(spectrum*cmf[0], wavelengths), \
-            simps(spectrum*cmf[1], wavelengths), \
-            simps(spectrum*cmf[2], wavelengths)
+            simpson(spectrum*cmf[0], wavelengths), \
+            simpson(spectrum*cmf[1], wavelengths), \
+            simpson(spectrum*cmf[2], wavelengths)
 
     def rgb(self, wavelengths: np.ndarray, spectrum: np.ndarray) \
             -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -456,9 +456,9 @@ class Observer:
         rgb_cmf = self.rgb_cmf(wavelengths)
 
         return \
-            simps(spectrum*rgb_cmf[0], wavelengths), \
-            simps(spectrum*rgb_cmf[1], wavelengths), \
-            simps(spectrum*rgb_cmf[2], wavelengths)
+            simpson(spectrum*rgb_cmf[0], wavelengths), \
+            simpson(spectrum*rgb_cmf[1], wavelengths), \
+            simpson(spectrum*rgb_cmf[2], wavelengths)
 
     def xyY(self, wavelengths: np.ndarray, spectrum: np.ndarray) -> np.ndarray:
         '''
@@ -1020,7 +1020,7 @@ class Illuminant:
                 raise ValueError('Unknown observer "{}"!'.format(observer))
             observer = observer_
 
-        XYZ = simps(
+        XYZ = simpson(
             observer.xyz_cmf(STANDARD_WAVELENGTHS)*
                 self.spd(STANDARD_WAVELENGTHS),
             dx=STANDARD_WAVELENGTH_STEP

--- a/xopto/util/convolve.py
+++ b/xopto/util/convolve.py
@@ -22,7 +22,7 @@
 
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.integrate import simps
+from scipy.integrate import simpson
 
 def fiber_reflectance(r: np.ndarray, reflectance: np.ndarray,
                       sds: float or np.ndarray, dcore: float,
@@ -112,7 +112,7 @@ def fiber_reflectance(r: np.ndarray, reflectance: np.ndarray,
 
         # Take care of special case when sds = 0.0.
         if d == 0.0:
-            fiber_reflectance[:, index] = 2.0*np.pi*simps(
+            fiber_reflectance[:, index] = 2.0*np.pi*simpson(
                 fsimps*rsimps, x=simps_r, dx=simps_dr
             )
 
@@ -120,7 +120,7 @@ def fiber_reflectance(r: np.ndarray, reflectance: np.ndarray,
             # First element of rsimps might be zero ... precision!
             d_times_rsimps = rsimps*d
             d_times_rsimps[d_times_rsimps == 0.0] = np.finfo(np.float64).tiny
-            fiber_reflectance[:, index] = 2.0*simps(
+            fiber_reflectance[:, index] = 2.0*simpson(
                 np.arccos(
                     np.clip(
                         (rsimps**2 + d**2 - rfib**2)/(2.0*d_times_rsimps),


### PR DESCRIPTION
recent versions of scipy enforced some expired deprecations https://docs.scipy.org/doc/scipy/release/1.14.0-notes.html#expired-deprecations

among them, `scipy.integrate.simps` is now called `scipy.integrate.simpson` (which was already available for used since a few releases)

I replaced the offending imports in the codebase and removed a few unused ones, but haven't checked yet if anything else was broken in the process.